### PR TITLE
Enabling DB level RUs

### DIFF
--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
@@ -88,7 +88,9 @@ namespace Eshopworld.Caching.Cosmos
                 docCol.PartitionKey = new PartitionKeyDefinition() { Paths = new Collection<string>() {"/id"} };
             }
 
-            var dc = DocumentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(_dbName), docCol,new RequestOptions() {OfferThroughput = _settings.NewCollectionDefaultDTU})
+            var requestOptions = _settings.DtuDefinedInCosmos ? null : new RequestOptions {OfferThroughput = _settings.NewCollectionDefaultDTU};
+
+            var dc = DocumentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(_dbName), docCol, requestOptions)
                                    .ConfigureAwait(false)
                                    .GetAwaiter()
                                    .GetResult();

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
@@ -88,7 +88,7 @@ namespace Eshopworld.Caching.Cosmos
                 docCol.PartitionKey = new PartitionKeyDefinition() { Paths = new Collection<string>() {"/id"} };
             }
 
-            var requestOptions = _settings.DatabaseSharedRUs ? null : new RequestOptions {OfferThroughput = _settings.NewCollectionDefaultDTU};
+            var requestOptions = _settings.UseDatabaseSharedThroughput ? null : new RequestOptions {OfferThroughput = _settings.NewCollectionDefaultDTU};
 
             var dc = DocumentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(_dbName), docCol, requestOptions)
                                    .ConfigureAwait(false)

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactory.cs
@@ -88,7 +88,7 @@ namespace Eshopworld.Caching.Cosmos
                 docCol.PartitionKey = new PartitionKeyDefinition() { Paths = new Collection<string>() {"/id"} };
             }
 
-            var requestOptions = _settings.DtuDefinedInCosmos ? null : new RequestOptions {OfferThroughput = _settings.NewCollectionDefaultDTU};
+            var requestOptions = _settings.DatabaseSharedRUs ? null : new RequestOptions {OfferThroughput = _settings.NewCollectionDefaultDTU};
 
             var dc = DocumentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(_dbName), docCol, requestOptions)
                                    .ConfigureAwait(false)

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
@@ -5,9 +5,13 @@
         public CosmosCache.InsertMode InsertMode { get; set; } = CosmosCache.InsertMode.JSON;
         public int NewCollectionDefaultDTU { get; set; } = 400;
         public int DefaultTimeToLive { get; set; } = -1;  //never expire by default
-        public bool UseKeyAsPartitionKey { get; set; } = false;
+        public bool UseKeyAsPartitionKey { get; set; }
         public CosmosCacheFactoryIndexingSettings IndexingSettings { get; set; } = new CosmosCacheFactoryIndexingSettings();
-        public bool DtuDefinedInCosmos { get; set; } = false;
+        /// <summary>
+        /// If the Database does NOT have a user-defined RU setting and this setting is set to true,
+        /// any on-the-fly created Collection will still default to 400 RUs
+        /// </summary>
+        public bool DatabaseSharedRUs { get; set; }
 
         public static readonly CosmosCacheFactorySettings Default = new CosmosCacheFactorySettings();
     }

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
@@ -8,9 +8,13 @@
         public bool UseKeyAsPartitionKey { get; set; }
         public CosmosCacheFactoryIndexingSettings IndexingSettings { get; set; } = new CosmosCacheFactoryIndexingSettings();
         /// <summary>
-        /// If the Database does NOT have a user-defined RU setting and this setting is set to true,
-        /// any on-the-fly created Collection will still default to 400 RUs
+        /// Enables using shared throughput provisioned on a database.
         /// </summary>
+        /// <remarks>
+        /// When disabled, collections will be created with dedicated throughput defined by <see cref="NewCollectionDefaultDTU" />.
+        /// When enabled new collections will share the throughput provisioned on the parent database.
+        /// If the database has no provisioned throughput then new collections will have the dedicated default throughput (400 RUs).
+        /// </remarks>
         public bool UseDatabaseSharedThroughput { get; set; }
 
         public static readonly CosmosCacheFactorySettings Default = new CosmosCacheFactorySettings();

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
@@ -5,8 +5,9 @@
         public CosmosCache.InsertMode InsertMode { get; set; } = CosmosCache.InsertMode.JSON;
         public int NewCollectionDefaultDTU { get; set; } = 400;
         public int DefaultTimeToLive { get; set; } = -1;  //never expire by default
-        public bool UseKeyAsPartitionKey {get;set;} = false;
+        public bool UseKeyAsPartitionKey { get; set; } = false;
         public CosmosCacheFactoryIndexingSettings IndexingSettings { get; set; } = new CosmosCacheFactoryIndexingSettings();
+        public bool DtuDefinedInCosmos { get; set; } = false;
 
         public static readonly CosmosCacheFactorySettings Default = new CosmosCacheFactorySettings();
     }

--- a/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCacheFactorySettings.cs
@@ -11,7 +11,7 @@
         /// If the Database does NOT have a user-defined RU setting and this setting is set to true,
         /// any on-the-fly created Collection will still default to 400 RUs
         /// </summary>
-        public bool DatabaseSharedRUs { get; set; }
+        public bool UseDatabaseSharedThroughput { get; set; }
 
         public static readonly CosmosCacheFactorySettings Default = new CosmosCacheFactorySettings();
     }

--- a/src/Eshopworld.Caching.Cosmos/Eshopworld.Caching.Cosmos.csproj
+++ b/src/Eshopworld.Caching.Cosmos/Eshopworld.Caching.Cosmos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <PackageReleaseNotes>Extended IndexingPolicy for the collection.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
+++ b/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
@@ -151,7 +151,7 @@ public class CosmosCacheFactoryTests
         var tempDbName = Guid.NewGuid().ToString();
         var collectionUri = UriFactory.CreateDocumentCollectionUri(tempDbName, tempCollectionName);
         var databaseUri = UriFactory.CreateDatabaseUri(tempDbName);
-        var offerThroughput = 500;
+        var offerThroughput = 400;
         var cosmosCacheFactorySettings = new CosmosCacheFactorySettings
         {
             UseDatabaseSharedThroughput = true,
@@ -164,7 +164,7 @@ public class CosmosCacheFactoryTests
             // Act
             await client.CreateDatabaseAsync(new Database { Id = tempDbName }, new RequestOptions
             {
-                OfferThroughput = offerThroughput //non-default
+                OfferThroughput = offerThroughput
             });
             
             //ensure temp collection is created

--- a/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
+++ b/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
@@ -154,7 +154,7 @@ public class CosmosCacheFactoryTests
         var offerThroughput = 500;
         var cosmosCacheFactorySettings = new CosmosCacheFactorySettings
         {
-            DatabaseSharedRUs = true,
+            UseDatabaseSharedThroughput = true,
             UseKeyAsPartitionKey = true
         };
 
@@ -244,7 +244,7 @@ public class CosmosCacheFactoryTests
         var cosmosCacheFactorySettings = new CosmosCacheFactorySettings
         {
             UseKeyAsPartitionKey = true,
-            DatabaseSharedRUs = true
+            UseDatabaseSharedThroughput = true
         };
 
         using (var factory = new CosmosCacheFactory(LocalClusterCosmosDb.ConnectionURI, LocalClusterCosmosDb.AccessKey, LocalClusterCosmosDb.DbName, cosmosCacheFactorySettings))


### PR DESCRIPTION
Added option to NOT set the collection RUs when creating it.
This enables shared RUs at the DB level.

PS: Could not find a way to get the collection level RUs via SDK that's why there is no test for this feature, tried and failed. Any ideas?

Thanks.