### PR TITLE
Add partition key if it is required when remove entries

### DIFF
--- a/src/Eshopworld.Caching.Cosmos/CosmosCache.cs
+++ b/src/Eshopworld.Caching.Cosmos/CosmosCache.cs
@@ -111,7 +111,12 @@ namespace Eshopworld.Caching.Cosmos
         public Task<bool> KeyExpireAsync(string key, TimeSpan? expiry) => Task.FromResult(false);
 
         public void Remove(string key) => RemoveAsync(key).GetAwaiter().GetResult();
-        public Task RemoveAsync(string key) => DocumentClient.DeleteDocumentAsync(CreateDocumentURI(key));
+
+        public async Task RemoveAsync(string key)
+        {
+            var requestOptions = _usePartitionKey ? new RequestOptions() { PartitionKey = new PartitionKey(key) } : null;
+            await DocumentClient.DeleteDocumentAsync(CreateDocumentURI(key), requestOptions).ConfigureAwait(false);
+        }
 
         public async Task<T> GetAsync(string key) => (await GetResultAsync(key).ConfigureAwait(false)).Value;
         public T Get(string key) => GetResult(key).Value;

--- a/src/Eshopworld.Caching.Cosmos/Eshopworld.Caching.Cosmos.csproj
+++ b/src/Eshopworld.Caching.Cosmos/Eshopworld.Caching.Cosmos.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>1.5.0</Version>
-    <PackageReleaseNotes>Extended IndexingPolicy for the collection.</PackageReleaseNotes>
+    <Version>1.5.1</Version>
+    <PackageReleaseNotes>Use partition key when remove entries.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
+++ b/src/Tests/Eshopworld.Caching.Cosmos.Tests/CosmosCacheFactoryTests.cs
@@ -104,7 +104,10 @@ public class CosmosCacheFactoryTests
             var actualIndexingPolicy = (await client.ReadDocumentCollectionAsync(collectionUri))
                 .Resource.IndexingPolicy;
 
-            Assert.Single(actualIndexingPolicy.ExcludedPaths);
+            // _etag is excluded by default
+            var excludedPaths = actualIndexingPolicy.ExcludedPaths.Where(x => x.Path != "/\"_etag\"/?").ToArray();
+
+            Assert.Single(excludedPaths);
             Assert.Contains(actualIndexingPolicy.ExcludedPaths, x => x.Path == "/*");
 
             Assert.Equal(2, actualIndexingPolicy.IncludedPaths.Count);
@@ -133,7 +136,10 @@ public class CosmosCacheFactoryTests
             var actualIndexingPolicy = (await client.ReadDocumentCollectionAsync(collectionUri))
                 .Resource.IndexingPolicy;
 
-            Assert.Empty(actualIndexingPolicy.ExcludedPaths);
+            // _etag is excluded by default
+            var excludedPaths = actualIndexingPolicy.ExcludedPaths.Where(x => x.Path != "/\"_etag\"/?").ToArray();
+
+            Assert.Empty(excludedPaths);
 
             Assert.Single(actualIndexingPolicy.IncludedPaths);
             Assert.Contains(actualIndexingPolicy.IncludedPaths, x => x.Path == "/*");


### PR DESCRIPTION
Currently, an exception is thrown when an entry is removed without partition key

```
System.InvalidOperationException: 'PartitionKey value must be supplied for this operation.'
```

Tests are updated because now there is an excluded path by default (https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cosmos-db/index-policy.md#includeexclude-strategy)